### PR TITLE
When (re-)generating the CSV file use minimal quoting

### DIFF
--- a/src/Indexer.php
+++ b/src/Indexer.php
@@ -32,7 +32,7 @@ class Indexer {
     foreach ($data as $i => &$row) {
       $guid = &$row[$guid_column];
       if ($i === 0) {
-        fputcsv($fp, $row);
+        Util::customFputcsv($fp, $row);
         continue;
       }
       if (empty($guid)) {
@@ -48,7 +48,7 @@ class Indexer {
         $guid = Util::createGuid();
       }
       $guids[] = $guid;
-      fputcsv($fp, $row);
+      Util::customFputcsv($fp, $row);
     }
     fclose($fp);
     Util::msg('Successfully reindexed "data.csv"');

--- a/src/Util.php
+++ b/src/Util.php
@@ -379,4 +379,16 @@ class Util {
     $dir->close();
     return true;
   }
+  public static function customFputcsv($file, $row) {
+    $temp_file = fopen("php://memory", "r+");
+    $temp_array = array ();
+    foreach ($row as $field) {
+      $temp_array[] = str_replace(" ", "\0", $field);
+    }
+    fputcsv($temp_file, $temp_array);
+    rewind($temp_file);
+    $string = str_replace("\0", " ", stream_get_contents($temp_file));
+    fwrite($file, $string);
+    fclose($temp_file);
+  }
 }


### PR DESCRIPTION
(Quote only when the field contains `,` `"` or a new line, not when it contains a space, but not the other characters.)

This is a rather hack-ish solution. It's also the first PHP code that I've ever written (other than fiddling with mediawiki and wordpress templates several years ago), so it may well not be very pretty code. I haven't seen a noticeable slow-down when running `composer index` on the anki-ultimate-geography deck, though.

I decided to write with fputcsv to a temporary buffer and then patch this output, to avoid writing my own CSV parser and possibly introducing my own bugs.